### PR TITLE
Cleanups

### DIFF
--- a/clamg/__init__.py
+++ b/clamg/__init__.py
@@ -5,12 +5,21 @@ __version__ = 0.2
 
 class Base:
     def __init__(self, *args, **kwargs):
-        for a in args:  
+        for a in args:
             if type(a) is dict:
                 self.__dict__ = a
         for k, v in kwargs.items():
             if k in allkw:
                 self.__dict__.update({k:v})
+
+    def __getitem__(self, key):
+        return self.__dict__[key]
+
+    def __contains__(self, key):
+        return key in self.__dict__
+
+    def __iter__(self):
+        return iter(self.__dict__)
 
     def __repr__(self):
         items = [f'{k}={v}' for k, v in self.__dict__.items()]

--- a/clamg/__init__.py
+++ b/clamg/__init__.py
@@ -34,7 +34,7 @@ def load(n):
         data = Loader(f.read()).get_data()
     return unpack(data)
 
-def unpack(i, c=0, rk=''):
+def unpack(i, c=0, rk='clamg'):
     c += 1
     attrs = {}
     if type(i) is dict:


### PR DESCRIPTION
I find that sometimes I want item access rather than attribute access.  If I know the name of an attribute programmatically, then attribute access is best.  But if a variable holds the attribute name, then item access is better.
Yes, I realize I could use getattr and hasattr, but I also could use yaml.safe_load with item access.  The whole point of clamg is to make things easier on the programmer.

Also, the outermost class has an empty name.  That produces odd results.